### PR TITLE
chore: bench optimisations

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -49,11 +49,11 @@ run: build
 
 # Run with the gateway example config (api_gateway mode)
 run-gateway: build
-    ./target/debug/locci-proxy --config examples/json-server/config-gateway.yaml
+    ./target/debug/locci-proxy --config examples/config-gateway.yaml
 
 # Run with the lb example config (load_balancer mode)
 run-lb: build
-    ./target/debug/locci-proxy --config examples/json-server/config-lb.yaml
+    ./target/debug/locci-proxy --config examples/config-lb.yaml
 
 # Kill any running locci-proxy instance (by name and by port)
 kill:
@@ -152,25 +152,41 @@ build-release:
 
 # Benchmark an upstream directly, bypassing the proxy (requires just servers-lb)
 # This establishes the ceiling that locci-proxy cannot exceed.
-bench-baseline:
+bench-baseline: build-release servers-lb
     #!/usr/bin/env bash
     THREADS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
+    sleep 1.5
     echo "--- Baseline: direct to upstream :3001 (no proxy) ---"
     rewrk -h http://127.0.0.1:3001/instance -t "$THREADS" -c 100 -d 10s --pct
+    pkill -f "json-server" 2>/dev/null || true
 
-# Benchmark through the proxy in lb mode (requires just servers-lb + proxy running)
-bench-lb:
+# Benchmark through the proxy in lb mode using the release binary
+bench-lb: build-release servers-lb
     #!/usr/bin/env bash
+    set -e
     THREADS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
-    echo "--- LB mode: through proxy :8484 ---"
-    rewrk -h http://127.0.0.1:8484/instance -t "$THREADS" -c 100 -d 10s --pct
+    sleep 1.5
+    ./target/release/locci-proxy --config examples/config-lb.yaml > /tmp/proxy-bench-lb.log 2>&1 &
+    PROXY_PID=$!
+    sleep 1.5
+    echo "--- LB mode (release): through proxy :8484 ---"
+    rewrk -h http://127.0.0.1:8484/instance -t "$THREADS" -c 100 -d 300s --pct
+    kill "$PROXY_PID" 2>/dev/null || true
+    pkill -f "json-server" 2>/dev/null || true
 
-# Benchmark through the proxy in gateway mode (requires just servers-gateway + proxy running)
-bench-gateway:
+# Benchmark through the proxy in gateway mode using the release binary
+bench-gateway: build-release servers-gateway
     #!/usr/bin/env bash
+    set -e
     THREADS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
-    echo "--- Gateway mode: through proxy :8484 ---"
+    sleep 1.5
+    ./target/release/locci-proxy --config examples/config-gateway.yaml > /tmp/proxy-bench-gw.log 2>&1 &
+    PROXY_PID=$!
+    sleep 1.5
+    echo "--- Gateway mode (release): through proxy :8484 ---"
     rewrk -h http://127.0.0.1:8484/users -t "$THREADS" -c 100 -d 10s --pct
+    kill "$PROXY_PID" 2>/dev/null || true
+    pkill -f "json-server" 2>/dev/null || true
 
 # Full automated benchmark: builds release binary, starts upstreams, runs baseline
 # then proxied, prints both results side-by-side, then cleans up.
@@ -182,7 +198,7 @@ bench: build-release servers-lb
     echo ""
 
     # Start the release proxy in the background
-    ./target/release/locci-proxy --config examples/json-server/config-lb.yaml > /tmp/proxy-bench.log 2>&1 &
+    ./target/release/locci-proxy --config examples/config-lb.yaml > /tmp/proxy-bench.log 2>&1 &
     PROXY_PID=$!
     sleep 1.5   # wait for bind
 
@@ -198,6 +214,217 @@ bench: build-release servers-lb
     pkill -f "json-server" 2>/dev/null || true
     echo ""
     echo "Done. Proxy log: /tmp/proxy-bench.log"
+
+# ── Go bench upstreams ────────────────────────────────────────────────────────
+# Fast multi-threaded replacements for json-server. No dependencies beyond Go stdlib.
+# Serve /instance (singleton) and /items (array) — same JSON shape as the lb fixtures.
+
+# Start three Go bench-upstream instances (mirrors servers-lb but much faster)
+servers-lb-go:
+    #!/usr/bin/env bash
+    go run examples/go/lb-upstream.go 3001 > /tmp/go-lb-1.log 2>&1 & echo "server-1 → :3001  (PID $!)"
+    go run examples/go/lb-upstream.go 3002 > /tmp/go-lb-2.log 2>&1 & echo "server-2 → :3002  (PID $!)"
+    go run examples/go/lb-upstream.go 3003 > /tmp/go-lb-3.log 2>&1 & echo "server-3 → :3003  (PID $!)"
+
+# Stop all Go bench-upstream instances
+servers-lb-go-stop:
+    #!/usr/bin/env bash
+    pkill -f "lb-upstream" 2>/dev/null && echo "go bench-upstreams stopped" || echo "none running"
+
+# Baseline: direct to Go upstream :3001 (no proxy) — establishes the ceiling
+bench-baseline-go: servers-lb-go
+    #!/usr/bin/env bash
+    THREADS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
+    sleep 3
+    echo "--- Baseline (Go upstream): direct to :3001 (no proxy) ---"
+    rewrk -h http://127.0.0.1:3001/instance -t "$THREADS" -c 100 -d 10s --pct
+    pkill -f "lb-upstream" 2>/dev/null || true
+
+# Benchmark through the proxy in lb mode against Go upstreams using the release binary
+bench-lb-go: build-release servers-lb-go
+    #!/usr/bin/env bash
+    set -e
+    THREADS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
+    sleep 1.5
+    ./target/release/locci-proxy --config examples/config-lb.yaml > /tmp/proxy-bench-lb-go.log 2>&1 &
+    PROXY_PID=$!
+    sleep 3
+    echo "--- LB mode (release, Go upstreams): through proxy :8484 ---"
+    rewrk -h http://127.0.0.1:8484/instance -t "$THREADS" -c 100 -d 300s --pct
+    kill "$PROXY_PID" 2>/dev/null || true
+    pkill -f "lb-upstream" 2>/dev/null || true
+
+# Full automated Go-upstream benchmark: baseline then proxied, side-by-side.
+bench-go: build-release servers-lb-go
+    #!/usr/bin/env bash
+    set -e
+    THREADS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
+    echo "Threads: $THREADS   Connections: 100   Duration: 10s   Upstreams: Go"
+    echo ""
+    sleep 3   # let Go servers finish compiling / binding
+
+    ./target/release/locci-proxy --config examples/config-lb.yaml > /tmp/proxy-bench-go.log 2>&1 &
+    PROXY_PID=$!
+    sleep 1.5
+
+    echo "=== 1/2  Baseline — direct to Go upstream :3001 (no proxy) ==="
+    rewrk -h http://127.0.0.1:3001/instance -t "$THREADS" -c 100 -d 10s --pct
+
+    echo ""
+    echo "=== 2/2  Proxied — through locci-proxy :8484 (lb mode, Go upstreams) ==="
+    rewrk -h http://127.0.0.1:8484/instance -t "$THREADS" -c 100 -d 10s --pct
+
+    kill "$PROXY_PID" 2>/dev/null || true
+    pkill -f "lb-upstream" 2>/dev/null || true
+    echo ""
+    echo "Done. Proxy log: /tmp/proxy-bench-go.log"
+
+# Start three Go gateway upstreams (users/:3001, products/:3002, web/:3003)
+servers-gateway-go:
+    #!/usr/bin/env bash
+    go run examples/go/gateway-upstream.go users    3001 > /tmp/go-gw-users.log    2>&1 & echo "users    → :3001  (PID $!)"
+    go run examples/go/gateway-upstream.go products 3002 > /tmp/go-gw-products.log 2>&1 & echo "products → :3002  (PID $!)"
+    go run examples/go/gateway-upstream.go web      3003 > /tmp/go-gw-web.log      2>&1 & echo "web      → :3003  (PID $!)"
+
+# Stop all Go gateway upstream instances
+servers-gateway-go-stop:
+    #!/usr/bin/env bash
+    pkill -f "gateway-upstream" 2>/dev/null && echo "go gateway-upstreams stopped" || echo "none running"
+
+# Baseline: direct to Go users upstream :3001 (no proxy)
+bench-baseline-gateway-go: servers-gateway-go
+    #!/usr/bin/env bash
+    THREADS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
+    sleep 3
+    echo "--- Baseline (Go gateway upstream): direct to :3001/users (no proxy) ---"
+    rewrk -h http://127.0.0.1:3001/users -t "$THREADS" -c 100 -d 10s --pct
+    pkill -f "gateway-upstream" 2>/dev/null || true
+
+# Benchmark through the proxy in gateway mode against Go upstreams using the release binary
+bench-gateway-go: build-release servers-gateway-go
+    #!/usr/bin/env bash
+    set -e
+    THREADS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
+    sleep 1.5
+    ./target/release/locci-proxy --config examples/config-gateway.yaml > /tmp/proxy-bench-gw-go.log 2>&1 &
+    PROXY_PID=$!
+    sleep 3
+    echo "--- Gateway mode (release, Go upstreams): through proxy :8484 ---"
+    rewrk -h http://127.0.0.1:8484/users -t "$THREADS" -c 100 -d 300s --pct
+    kill "$PROXY_PID" 2>/dev/null || true
+    pkill -f "gateway-upstream" 2>/dev/null || true
+
+# Full automated Go-upstream gateway benchmark: baseline then proxied, side-by-side.
+bench-gateway-go-full: build-release servers-gateway-go
+    #!/usr/bin/env bash
+    set -e
+    THREADS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
+    echo "Threads: $THREADS   Connections: 100   Duration: 10s   Upstreams: Go (gateway)"
+    echo ""
+    sleep 3   # let Go servers finish compiling / binding
+
+    ./target/release/locci-proxy --config examples/config-gateway.yaml > /tmp/proxy-bench-gw-go.log 2>&1 &
+    PROXY_PID=$!
+    sleep 1.5
+
+    echo "=== 1/2  Baseline — direct to Go users upstream :3001 (no proxy) ==="
+    rewrk -h http://127.0.0.1:3001/users -t "$THREADS" -c 100 -d 10s --pct
+
+    echo ""
+    echo "=== 2/2  Proxied — through locci-proxy :8484 (gateway mode, Go upstreams) ==="
+    rewrk -h http://127.0.0.1:8484/users -t "$THREADS" -c 100 -d 10s --pct
+
+    kill "$PROXY_PID" 2>/dev/null || true
+    pkill -f "gateway-upstream" 2>/dev/null || true
+    echo ""
+    echo "Done. Proxy log: /tmp/proxy-bench-gw-go.log"
+
+# ── Docker ────────────────────────────────────────────────────────────────────
+
+# Build the Docker image (uses Dockerfile multi-stage / cargo-chef cache)
+docker-build:
+    docker build -t locci/proxy:latest .
+
+# Build and tag with a specific version
+# Usage: just docker-tag 0.2.0
+docker-tag version:
+    docker build -t locci/proxy:{{version}} -t locci/proxy:latest .
+
+# Run the container with config.yaml (gateway mode by default)
+docker-run:
+    docker run --rm \
+        -p 8484:8484 \
+        -p 8485:8485 \
+        -v "$(pwd)/config.yaml:/app/config.yaml:ro" \
+        -e RUST_LOG=${RUST_LOG:-info} \
+        --name locci-proxy \
+        locci/proxy:latest --config /app/config.yaml
+
+# Run the container with the lb example config
+docker-run-lb:
+    docker run --rm \
+        -p 8484:8484 \
+        -p 8485:8485 \
+        -v "$(pwd)/examples/config-lb.yaml:/app/config.yaml:ro" \
+        -e RUST_LOG=${RUST_LOG:-info} \
+        --name locci-proxy \
+        locci/proxy:latest --config /app/config.yaml
+
+# Run the container with the gateway example config
+docker-run-gateway:
+    docker run --rm \
+        -p 8484:8484 \
+        -p 8485:8485 \
+        -v "$(pwd)/examples/config-gateway.yaml:/app/config.yaml:ro" \
+        -e RUST_LOG=${RUST_LOG:-info} \
+        --name locci-proxy \
+        locci/proxy:latest --config /app/config.yaml
+
+# Stop and remove the running container
+docker-stop:
+    docker stop locci-proxy 2>/dev/null || true
+    docker rm   locci-proxy 2>/dev/null || true
+
+# Tail logs from the running container
+docker-logs:
+    docker logs -f locci-proxy
+
+# Remove the built image
+docker-clean:
+    docker rmi locci/proxy:latest 2>/dev/null || true
+
+# ── Docker Compose ────────────────────────────────────────────────────────────
+
+# Build and start the proxy via compose (uses config.yaml volume mount)
+compose-up:
+    docker compose up -d --build
+    @echo "Proxy:       http://localhost:8484"
+    @echo "Control API: http://localhost:8485"
+
+# Start without rebuilding
+compose-start:
+    docker compose up -d
+
+# Stop and remove containers (keeps volumes/images)
+compose-stop:
+    docker compose down
+
+# Stop and remove containers + image
+compose-down:
+    docker compose down --rmi local
+
+# Tail proxy logs
+compose-logs:
+    docker compose logs -f locci-proxy
+
+# Rebuild image without cache
+compose-rebuild:
+    docker compose build --no-cache
+    docker compose up -d
+
+# Show running compose services
+compose-ps:
+    docker compose ps
 
 # ── Monitoring ────────────────────────────────────────────────────────────────
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- TASK-012: Go bench upstreams — `examples/go/lb-upstream.go` and `examples/go/gateway-upstream.go`; multi-threaded stdlib servers serving the same JSON shape as json-server fixtures, eliminating the Node.js single-thread ceiling from benchmark results
+- TASK-012: Expanded justfile — Docker/compose recipes (`docker-build`, `docker-run`, `docker-run-lb`, `docker-run-gateway`, `compose-up`, `compose-down`, etc.); Go bench recipes (`servers-lb-go`, `bench-lb-go`, `bench-gateway-go`, `bench-go`, `bench-gateway-go-full`); all bench recipes now self-contained (build → start servers → start proxy → benchmark → cleanup)
 - TASK-007: Prometheus metrics — `locci_requests_total`, `locci_request_duration_seconds`, `locci_upstream_health`, `locci_errors_total`; Grafana monitoring stack in `monitoring/`; `just monitor` to start ([#17](https://github.com/MikeTeddyOmondi/locci-proxy/pull/17))
 - TASK-003: Control API bearer token auth — 401 on missing/wrong token; `api_key` and `jwt_secret` redacted in `/api/v1/config` response; auth skipped when `api_key` is unset ([#16](https://github.com/MikeTeddyOmondi/locci-proxy/pull/16))
 - TASK-002: Request timeout enforcement — `upstream_connect_timeout_secs` and `upstream_read_timeout_secs` added to `ServerConfig`; per-route `timeout_secs` overrides the global read timeout in gateway mode ([#15](https://github.com/MikeTeddyOmondi/locci-proxy/pull/15))
 - TASK-001: Gateway upstream load balancing — each upstream group in `api_gateway` now gets its own `LoadBalancer<RoundRobin>` with health-check background task; `upstream_peer` calls `lb.select()` instead of `servers.first()` ([#14](https://github.com/MikeTeddyOmondi/locci-proxy/pull/14))
 
 ### Fixed
+- TASK-012: Absolute-form URI forwarding — proxy was passing `GET http://host/path HTTP/1.1` verbatim to upstreams (origin form `GET /path` required); caused 100% HTTP 404 on all bench and rewrk traffic in both lb and gateway modes
+- TASK-012: Wire `workers` config to Pingora `ServerConf::threads` — field was parsed but `Server::new(None)` discarded it, leaving every deployment silently running on a single proxy thread
 - TASK-004: Pre-compile strip-prefix regex at startup — eliminates runtime `unwrap()` on the hot path ([#12](https://github.com/MikeTeddyOmondi/locci-proxy/pull/12))
 - TASK-008: Health check background task now registered with Pingora server — checks were configured but never ran ([#13](https://github.com/MikeTeddyOmondi/locci-proxy/pull/13))
+
+### Changed
+- TASK-012: Release profile optimisations — `opt-level=3`, `lto=thin`, `codegen-units=1`, `strip=true`, `panic=abort` added to `Cargo.toml`
+- TASK-012: Relocate example configs — `config-lb.yaml` and `config-gateway.yaml` moved from `examples/json-server/` to `examples/` root
 
 ### Planned (see TASKS.md)
 - TASK-001: Load balancing within gateway upstream groups (round-robin + failover)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,10 @@ regex = "1"
 once_cell = "1"
 uuid = { version = "1", features = ["v4"] }
 prometheus = { version = "0.13", features = ["process"] }
+
+[profile.release]
+opt-level     = 3      # maximum optimisation
+lto           = "thin" # cross-crate inlining without full LTO compile time cost
+codegen-units = 1      # single CGU lets LLVM see the whole crate for better inlining
+strip         = true   # remove debug symbols → smaller binary
+panic         = "abort" # skip unwinding machinery, slightly leaner hot paths

--- a/TASKS.md
+++ b/TASKS.md
@@ -218,14 +218,14 @@ There is no per-request logging. Debugging a live proxy means guessing which ups
 
 | Task | Branch | Status |
 |---|---|---|
-| TASK-001 | `feat/gateway-upstream-lb` | Open |
-| TASK-002 | `feat/request-timeouts` | Open |
-| TASK-003 | `feat/control-api-auth` | Open |
-| TASK-004 | `fix/strip-prefix-unwrap` | Open |
+| TASK-001 | `feat/gateway-upstream-lb` | Done (PR #14) |
+| TASK-002 | `feat/request-timeouts` | Done (PR #15) |
+| TASK-003 | `feat/control-api-auth` | Done (PR #16) |
+| TASK-004 | `fix/strip-prefix-unwrap` | Done (PR #12) |
 | TASK-005 | `feat/middleware-engine` | Open |
 | TASK-006 | `feat/tls-termination` | Open |
-| TASK-007 | `feat/prometheus-metrics` | Open |
-| TASK-008 | `fix/health-check-task` | Open |
+| TASK-007 | `feat/prometheus-metrics` | Done (PR #17) |
+| TASK-008 | `fix/health-check-task` | Done (PR #13) |
 | TASK-009 | `feat/hot-reload` | Open |
 | TASK-010 | `feat/connection-pool-config` | Open |
-| TASK-011 | `feat/structured-logging` | Open |
+| TASK-011 | `feat/structured-logging` | Done (PR #18) |

--- a/TASKS.md
+++ b/TASKS.md
@@ -214,6 +214,22 @@ There is no per-request logging. Debugging a live proxy means guessing which ups
 
 ---
 
+### TASK-012 — Benchmark infrastructure + proxy optimisations
+**Branch:** `chore/optimisations`
+
+**Problem:**
+Benchmarks produced 100% HTTP 404 responses; proxy worker count was silently ignored; no fast upstream alternative to single-threaded json-server existed for measuring real proxy overhead.
+
+**Work items:**
+- Fix absolute-form URI forwarding — proxy was passing `GET http://host/path` verbatim to upstreams instead of rewriting to origin form `GET /path`; affected both lb and gateway modes
+- Wire `workers` config field to Pingora `ServerConf::threads` — field was parsed but `Server::new(None)` discarded it, leaving the proxy on 1 thread
+- Add `[profile.release]` optimisations — `opt-level=3`, `lto=thin`, `codegen-units=1`, `strip=true`, `panic=abort`
+- Add Go bench upstreams (`examples/go/lb-upstream.go`, `examples/go/gateway-upstream.go`) — multi-threaded stdlib servers that serve the same JSON shape as json-server fixtures; eliminates Node.js single-thread ceiling from bench results
+- Relocate example configs — move `config-lb.yaml` and `config-gateway.yaml` from `examples/json-server/` to `examples/`
+- Expand justfile — Docker/compose recipes, Go bench recipes (`servers-lb-go`, `bench-lb-go`, `bench-gateway-go`, etc.), all bench recipes now self-contained (build-release + start servers + start proxy + cleanup)
+
+---
+
 ## Tracking
 
 | Task | Branch | Status |
@@ -229,3 +245,4 @@ There is no per-request logging. Debugging a live proxy means guessing which ups
 | TASK-009 | `feat/hot-reload` | Open |
 | TASK-010 | `feat/connection-pool-config` | Open |
 | TASK-011 | `feat/structured-logging` | Done (PR #18) |
+| TASK-012 | `chore/optimisations` | Open |

--- a/examples/config-gateway.yaml
+++ b/examples/config-gateway.yaml
@@ -12,7 +12,7 @@ logging:
 upstreams:
   users_server:
     servers:
-      - "127.0.0.1:3001"   # json-server --port 3001 db-users.json
+      - "127.0.0.1:3001"   # json-server --port 3001 examples/json-server/db-users.json
     strategy: round_robin
     tls: false
     health_check:
@@ -22,7 +22,7 @@ upstreams:
 
   products_server:
     servers:
-      - "127.0.0.1:3002"   # json-server --port 3002 db-products.json
+      - "127.0.0.1:3002"   # json-server --port 3002 examples/json-server/db-products.json
     strategy: round_robin
     tls: false
     health_check:
@@ -32,7 +32,7 @@ upstreams:
 
   web_server:
     servers:
-      - "127.0.0.1:3003"   # json-server --port 3003 db-web.json
+      - "127.0.0.1:3003"   # json-server --port 3003 examples/json-server/db-web.json
     strategy: round_robin
     tls: false
     health_check:

--- a/examples/config-lb.yaml
+++ b/examples/config-lb.yaml
@@ -2,7 +2,7 @@ mode: load_balancer
 
 server:
   bind_address: "0.0.0.0:8484"
-  workers: 4
+  workers: 2
   upstream_connect_timeout_secs: 10
   upstream_read_timeout_secs: 30
 
@@ -14,9 +14,9 @@ logging:
 upstreams:
   app_servers:
     servers:
-      - "127.0.0.1:3001"   # json-server --port 3001 db-lb-1.json
-      - "127.0.0.1:3002"   # json-server --port 3002 db-lb-2.json
-      - "127.0.0.1:3003"   # json-server --port 3003 db-lb-3.json
+      - "127.0.0.1:3001"   # json-server --port 3001 examples/json-server/db-lb-1.json
+      - "127.0.0.1:3002"   # json-server --port 3002 examples/json-server/db-lb-2.json
+      - "127.0.0.1:3003"   # json-server --port 3003 examples/json-server/db-lb-3.json
     strategy: round_robin
     tls: false
     health_check:

--- a/examples/go/gateway-upstream.go
+++ b/examples/go/gateway-upstream.go
@@ -1,0 +1,140 @@
+// gateway-upstream: minimal multi-threaded HTTP upstream for gateway-mode load-testing.
+// Mirrors the three json-server gateway fixtures (users / products / web).
+//
+// Usage: go run examples/go/gateway-upstream.go <service> [port]
+//
+//   service: users | products | web
+//   port:    default 3001
+//
+// Three instances cover the gateway setup:
+//   go run examples/go/gateway-upstream.go users    3001
+//   go run examples/go/gateway-upstream.go products 3002
+//   go run examples/go/gateway-upstream.go web      3003
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// ── Data fixtures ─────────────────────────────────────────────────────────────
+
+var users = []map[string]any{
+	{"id": "1", "name": "Alice", "email": "alice@example.com"},
+	{"id": "2", "name": "Bob", "email": "bob@example.com"},
+	{"id": "3", "name": "Carol", "email": "carol@example.com"},
+	{"id": "0607", "name": "Dave", "email": "dave@example.com"},
+}
+
+var products = []map[string]any{
+	{"id": "1", "name": "Widget", "price": 9.99},
+	{"id": "2", "name": "Gadget", "price": 24.99},
+	{"id": "3", "name": "Doohick", "price": 4.99},
+	{"id": "adb9", "name": "Thingamajig", "price": 14.99},
+}
+
+var pages = []map[string]any{
+	{"id": 1, "slug": "home", "title": "Home"},
+	{"id": 2, "slug": "about", "title": "About"},
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+// findByID returns the first element whose "id" field matches id, or nil.
+func findByID(collection []map[string]any, id string) map[string]any {
+	for _, item := range collection {
+		switch v := item["id"].(type) {
+		case string:
+			if v == id {
+				return item
+			}
+		case int:
+			if strconv.Itoa(v) == id {
+				return item
+			}
+		}
+	}
+	return nil
+}
+
+// collectionHandler returns an http.HandlerFunc for a named collection.
+// GET /collection       → full array
+// GET /collection/:id   → single item or 404
+func collectionHandler(name string, collection []map[string]any) http.HandlerFunc {
+	prefix := "/" + name + "/"
+	base := "/" + name
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if path == base || path == base+"/" {
+			writeJSON(w, http.StatusOK, collection)
+			return
+		}
+		if strings.HasPrefix(path, prefix) {
+			id := strings.TrimPrefix(path, prefix)
+			if item := findByID(collection, id); item != nil {
+				writeJSON(w, http.StatusOK, item)
+				return
+			}
+		}
+		http.NotFound(w, r)
+	}
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: gateway-upstream <users|products|web> [port]")
+		os.Exit(1)
+	}
+
+	service := os.Args[1]
+	port := 3001
+	if len(os.Args) > 2 {
+		p, err := strconv.Atoi(os.Args[2])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid port %q\n", os.Args[2])
+			os.Exit(1)
+		}
+		port = p
+	}
+
+	mux := http.NewServeMux()
+
+	switch service {
+	case "users":
+		mux.HandleFunc("/users", collectionHandler("users", users))
+		mux.HandleFunc("/users/", collectionHandler("users", users))
+	case "products":
+		mux.HandleFunc("/products", collectionHandler("products", products))
+		mux.HandleFunc("/products/", collectionHandler("products", products))
+	case "web":
+		mux.HandleFunc("/pages", collectionHandler("pages", pages))
+		mux.HandleFunc("/pages/", collectionHandler("pages", pages))
+	default:
+		fmt.Fprintf(os.Stderr, "unknown service %q — use: users | products | web\n", service)
+		os.Exit(1)
+	}
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	addr := fmt.Sprintf(":%d", port)
+	fmt.Printf("gateway-upstream %s → %s\n", service, addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/examples/go/lb-upstream.go
+++ b/examples/go/lb-upstream.go
@@ -1,0 +1,70 @@
+// lb-upstream: minimal multi-threaded HTTP upstream for load-testing locci-proxy in lb mode.
+// Serves /instance (singleton) and /items (array) — mirrors the json-server lb fixtures.
+//
+// Usage: go run examples/go/lb-upstream.go [port]   (default: 3001)
+//
+// Three instances cover the lb setup:
+//   go run examples/go/lb-upstream.go 3001
+//   go run examples/go/lb-upstream.go 3002
+//   go run examples/go/lb-upstream.go 3003
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+)
+
+var items = []map[string]any{
+	{"id": 1, "name": "Apple", "price": 1.99},
+	{"id": 2, "name": "Banana", "price": 0.99},
+	{"id": 3, "name": "Cherry", "price": 3.49},
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}
+
+func main() {
+	port := 3001
+	if len(os.Args) > 1 {
+		p, err := strconv.Atoi(os.Args[1])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid port %q\n", os.Args[1])
+			os.Exit(1)
+		}
+		port = p
+	}
+
+	id := port - 3000
+	instance := map[string]any{
+		"id":   id,
+		"name": fmt.Sprintf("server-%d", id),
+		"port": port,
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/instance", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, instance)
+	})
+
+	mux.HandleFunc("/items", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, items)
+	})
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	addr := fmt.Sprintf(":%d", port)
+	fmt.Printf("lb-upstream server-%d → %s\n", id, addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod metrics;
 mod services;
 
 use config::{OperationMode, UnifiedConfig, cli::parse_cli};
-use errors::{ProxyError, ProxyResult};
+use errors::ProxyResult;
 use services::ServiceManager;
 
 fn main() -> ProxyResult<()> {
@@ -64,11 +64,15 @@ fn main() -> ProxyResult<()> {
     metrics::init();
 
     // Pingora owns its runtime; plain fn main() + run_forever() is required.
+    let pingora_server_config = {
+        let mut server_conf = pingora_core::server::configuration::ServerConf::default();
+        if let Some(w) = config.server.workers {
+            server_conf.threads = w;
+        }
+        server_conf
+    };
     let mut server =
-        pingora_core::server::Server::new(None).map_err(|e| ProxyError::LoadBalancerBuild {
-            name: "pingora-server".to_owned(),
-            source: std::io::Error::other(e.to_string()),
-        })?;
+        pingora_core::server::Server::new_with_opt_and_conf(None, pingora_server_config);
     server.bootstrap();
 
     let manager = Arc::new(ServiceManager::new(config.clone()));

--- a/src/services/gateway.rs
+++ b/src/services/gateway.rs
@@ -86,7 +86,7 @@ impl GatewayProxy {
         }
 
         // Sort longest pattern first so specific routes always beat catch-alls (e.g. ^/).
-        routes.sort_by(|(a, _, _), (b, _, _)| b.as_str().len().cmp(&a.as_str().len()));
+        routes.sort_by_key(|(b, _, _)| std::cmp::Reverse(b.as_str().len()));
 
         Ok(Self {
             routes,

--- a/src/services/gateway.rs
+++ b/src/services/gateway.rs
@@ -182,26 +182,32 @@ impl ProxyHttp for GatewayProxy {
             .insert_header("x-request-id", ctx.request_id.as_str())
             .or_err(InternalError, "insert x-request-id")?;
 
+        // Proxy clients send absolute-form URIs ("GET http://host/path HTTP/1.1").
+        // Upstreams expect origin form ("GET /path HTTP/1.1"). Always normalise,
+        // and additionally strip the route prefix when strip_prefix: true.
         let path = session.req_header().uri.path().to_owned();
 
-        if let Some((_, Some(strip_re), _)) = self.match_route(&path) {
-            let new_path = strip_re.replace(&path, "").to_string();
-            let new_path = if new_path.is_empty() {
+        let new_path = if let Some((_, Some(strip_re), _)) = self.match_route(&path) {
+            let stripped = strip_re.replace(&path, "").to_string();
+            if stripped.is_empty() {
                 "/".to_owned()
             } else {
-                new_path
-            };
-            let uri = new_path.parse().map_err(|_| {
-                Error::explain(
-                    InternalError,
-                    ProxyError::InvalidUri {
-                        uri: new_path.clone(),
-                    }
-                    .to_string(),
-                )
-            })?;
-            upstream_request.set_uri(uri);
-        }
+                stripped
+            }
+        } else {
+            path
+        };
+
+        let uri = new_path.parse().map_err(|_| {
+            Error::explain(
+                InternalError,
+                ProxyError::InvalidUri {
+                    uri: new_path.clone(),
+                }
+                .to_string(),
+            )
+        })?;
+        upstream_request.set_uri(uri);
         Ok(())
     }
 

--- a/src/services/lb.rs
+++ b/src/services/lb.rs
@@ -70,13 +70,27 @@ impl ProxyHttp for LbProxy {
 
     async fn upstream_request_filter(
         &self,
-        _session: &mut Session,
+        session: &mut Session,
         upstream_request: &mut RequestHeader,
         ctx: &mut Self::CTX,
     ) -> Result<()> {
         upstream_request
             .insert_header("x-request-id", ctx.request_id.as_str())
             .or_err(InternalError, "insert x-request-id")?;
+
+        // Proxy clients send absolute-form URIs ("GET http://host/path HTTP/1.1").
+        // Upstreams expect origin form ("GET /path HTTP/1.1"). Normalise here.
+        let pq = session
+            .req_header()
+            .uri
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or("/");
+        let origin_uri = pq
+            .parse::<http::Uri>()
+            .or_err(InternalError, "rewrite upstream uri to origin form")?;
+        upstream_request.set_uri(origin_uri);
+
         Ok(())
     }
 


### PR DESCRIPTION
Closes #19

## Summary
- Fix absolute-form URI forwarding causing 100% 404s on all bench traffic (lb + gateway)
- Wire `workers` config to Pingora `ServerConf::threads` — was silently ignored, proxy ran on 1 thread
- Add release profile optimisations (`opt-level=3`, `lto=thin`, `codegen-units=1`, `strip`, `panic=abort`)
- Add Go bench upstreams replacing single-threaded json-server for accurate proxy overhead measurement
- Relocate example configs to `examples/` root
- Expand justfile with Docker/compose and Go bench recipes; make all bench recipes self-contained

## Test plan
- [x] `just bench-lb-go` completes with 0 errors and all `status=200` in proxy logs
- [ ] `just bench-gateway-go` completes with 0 errors
- [ ] `just bench-go` runs full automated baseline + proxied side-by-side
- [ ] `just docker-build` produces a valid image
- [ ] `just compose-up` starts the proxy container on `:8484`/`:8485`
- [ ] Config `workers: N` is reflected in Pingora thread count at startup